### PR TITLE
make python version more readable 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ zig-cache
 zig-out
 node_modules
 *.class
+__pycache__

--- a/python/lexer/lexer.py
+++ b/python/lexer/lexer.py
@@ -39,8 +39,8 @@ class Lexer:
             return tok
 
         if is_letter(self.ch):
-            indent = self.read_ident()
-            return keywords.get(indent, Token(TokenType.Ident, indent))
+            ident = self.read_ident()
+            return keywords.get(ident, Token(TokenType.Ident, ident))
         
         if self.ch.isdigit():
             return Token(TokenType.Int, self.read_int())

--- a/python/lexer/lexer.py
+++ b/python/lexer/lexer.py
@@ -1,13 +1,12 @@
 from tokens import Token, TokenType, char_to_token_type
 
 
-keywords = {
-    'fn' : Token(TokenType.Function, 'fn'),
-    'let': Token(TokenType.Let, 'let')
-}
+keywords = {"fn": Token(TokenType.Function, "fn"), "let": Token(TokenType.Let, "let")}
+
 
 def is_letter(ch):
-    return ch.isalpha() or ch == '_'
+    return ch.isalpha() or ch == "_"
+
 
 class Lexer:
     def __init__(self, input):
@@ -15,22 +14,21 @@ class Lexer:
         self.input_length = len(self.input)
         self.position = 0
         self.read_position = 0
-        self.ch = ''
+        self.ch = ""
         self.read_char()
 
     def read_char(self) -> None:
-        if self.read_position >=  self.input_length:
-            self.ch = '\0'
+        if self.read_position >= self.input_length:
+            self.ch = "\0"
         else:
             self.ch = self.input[self.read_position]
-        
+
         self.position = self.read_position
         self.read_position += 1
-        
 
     def get_next_token(self) -> Token:
         self.skip_whitespace()
-        
+
         # I dont wanna write if else for each character
         tok_type = char_to_token_type.get(self.ch, None)
         if tok_type is not None:
@@ -41,29 +39,28 @@ class Lexer:
         if is_letter(self.ch):
             ident = self.read_ident()
             return keywords.get(ident, Token(TokenType.Ident, ident))
-        
+
         if self.ch.isdigit():
             return Token(TokenType.Int, self.read_int())
-        
-        return Token(TokenType.Illegal, self.ch)
 
+        return Token(TokenType.Illegal, self.ch)
 
     def read_int(self) -> str:
         pos = self.position
-        
+
         while self.ch.isdigit():
             self.read_char()
-        
-        return self.input[pos:self.position]
+
+        return self.input[pos : self.position]
 
     def read_ident(self) -> str:
         pos = self.position
-        
+
         while is_letter(self.ch):
             self.read_char()
 
-        return self.input[pos:self.position]
+        return self.input[pos : self.position]
 
     def skip_whitespace(self):
-        while(self.ch.isspace()):
+        while self.ch.isspace():
             self.read_char()

--- a/python/lexer/lexer_test.py
+++ b/python/lexer/lexer_test.py
@@ -6,17 +6,17 @@ from tokens import Token, TokenType
 
 class Test(unittest.TestCase):
     def test_get_next_token_1(self):
-        input = '=+(){},;'
-        
+        input = "=+(){},;"
+
         tokens = [
-        TokenType.Equal,
-        TokenType.Plus,
-        TokenType.LParen,
-        TokenType.RParen,
-        TokenType.LSquirly,
-        TokenType.RSquirly,
-        TokenType.Comma,
-        TokenType.Semicolon,
+            TokenType.Equal,
+            TokenType.Plus,
+            TokenType.LParen,
+            TokenType.RParen,
+            TokenType.LSquirly,
+            TokenType.RSquirly,
+            TokenType.Comma,
+            TokenType.Semicolon,
         ]
 
         lex = Lexer(input)
@@ -24,53 +24,53 @@ class Test(unittest.TestCase):
             self.assertEqual(lex.get_next_token().type, token)
 
     def test_get_next_token_2(self):
-        input ='''\
+        input = """\
 let five = 5;
 let ten = 10;
 let add = fn(x, y) {
     x + y;
 };
 let result = add(five, ten);
-'''
+"""
         lex = Lexer(input)
         tokens = [
-        Token(TokenType.Let, "let"),
-        Token(TokenType.Ident, "five" ),
-        Token(TokenType.Equal, "="),
-        Token(TokenType.Int, "5" ),
-        Token(TokenType.Semicolon, ";"),
-        Token(TokenType.Let, "let"),
-        Token(TokenType.Ident, "ten" ),
-        Token(TokenType.Equal, "="),
-        Token(TokenType.Int, "10" ),
-        Token(TokenType.Semicolon, ";"),
-        Token(TokenType.Let, "let"),
-        Token(TokenType.Ident, "add" ),
-        Token(TokenType.Equal, "="),
-        Token(TokenType.Function, "fn"),
-        Token(TokenType.LParen, "("),
-        Token(TokenType.Ident, "x" ),
-        Token(TokenType.Comma, ","),
-        Token(TokenType.Ident, "y" ),
-        Token(TokenType.RParen, ")"),
-        Token(TokenType.LSquirly, "{"),
-        Token(TokenType.Ident, "x" ),
-        Token(TokenType.Plus, "+"),
-        Token(TokenType.Ident, "y" ),
-        Token(TokenType.Semicolon, ";"),
-        Token(TokenType.RSquirly, "}"),
-        Token(TokenType.Semicolon, ";"),
-        Token(TokenType.Let, "let"),
-        Token(TokenType.Ident, "result" ),
-        Token(TokenType.Equal, "="),
-        Token(TokenType.Ident, "add" ),
-        Token(TokenType.LParen, "("),
-        Token(TokenType.Ident, "five" ),
-        Token(TokenType.Comma, ","),
-        Token(TokenType.Ident, "ten" ),
-        Token(TokenType.RParen, ")"),
-        Token(TokenType.Semicolon, ";"),
-        Token(TokenType.Eof, "EOF"),
-        ] 
+            Token(TokenType.Let, "let"),
+            Token(TokenType.Ident, "five"),
+            Token(TokenType.Equal, "="),
+            Token(TokenType.Int, "5"),
+            Token(TokenType.Semicolon, ";"),
+            Token(TokenType.Let, "let"),
+            Token(TokenType.Ident, "ten"),
+            Token(TokenType.Equal, "="),
+            Token(TokenType.Int, "10"),
+            Token(TokenType.Semicolon, ";"),
+            Token(TokenType.Let, "let"),
+            Token(TokenType.Ident, "add"),
+            Token(TokenType.Equal, "="),
+            Token(TokenType.Function, "fn"),
+            Token(TokenType.LParen, "("),
+            Token(TokenType.Ident, "x"),
+            Token(TokenType.Comma, ","),
+            Token(TokenType.Ident, "y"),
+            Token(TokenType.RParen, ")"),
+            Token(TokenType.LSquirly, "{"),
+            Token(TokenType.Ident, "x"),
+            Token(TokenType.Plus, "+"),
+            Token(TokenType.Ident, "y"),
+            Token(TokenType.Semicolon, ";"),
+            Token(TokenType.RSquirly, "}"),
+            Token(TokenType.Semicolon, ";"),
+            Token(TokenType.Let, "let"),
+            Token(TokenType.Ident, "result"),
+            Token(TokenType.Equal, "="),
+            Token(TokenType.Ident, "add"),
+            Token(TokenType.LParen, "("),
+            Token(TokenType.Ident, "five"),
+            Token(TokenType.Comma, ","),
+            Token(TokenType.Ident, "ten"),
+            Token(TokenType.RParen, ")"),
+            Token(TokenType.Semicolon, ";"),
+            Token(TokenType.Eof, "EOF"),
+        ]
         for token in tokens:
             self.assertEqual(lex.get_next_token(), token)

--- a/python/lexer/main.py
+++ b/python/lexer/main.py
@@ -1,7 +1,7 @@
 from lexer import Lexer
 
-if __name__ == '__main__':
-    input = '=+(){},;'
+if __name__ == "__main__":
+    input = "=+(){},;"
     lex = Lexer(input)
     for c in input:
         print(lex.get_next_token())

--- a/python/lexer/tokens.py
+++ b/python/lexer/tokens.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from dataclasses import dataclass
 
+
 class TokenType(Enum):
     Illegal = "ILLEGAL"
     Eof = "EOF"
@@ -17,17 +18,19 @@ class TokenType(Enum):
     Function = "FUNCTION"
     Let = "LET"
 
+
 char_to_token_type = {
-    '=': TokenType.Equal,
-    '+': TokenType.Plus,
-    ',': TokenType.Comma,
-    ';': TokenType.Semicolon,
-    '(': TokenType.LParen,
-    ')': TokenType.RParen,
-    '{': TokenType.LSquirly,
-    '}': TokenType.RSquirly,
-    '\x00': TokenType.Eof
+    "=": TokenType.Equal,
+    "+": TokenType.Plus,
+    ",": TokenType.Comma,
+    ";": TokenType.Semicolon,
+    "(": TokenType.LParen,
+    ")": TokenType.RParen,
+    "{": TokenType.LSquirly,
+    "}": TokenType.RSquirly,
+    "\x00": TokenType.Eof,
 }
+
 
 @dataclass
 class Token:


### PR DESCRIPTION
I've fixed a typo, added python bytecode to the .gitignore and ran a formatter over the code. The functionality/logic hasn't changed.