### PR TITLE
Initial CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,22 @@
+# Global owners.
+@ThePrimeagen
+
+# Degenerate language maintainers.
+/c/             @zivlakmilos
+/cpp/           @nicdgonzalez
+/crystal/       @devnote-dev
+/csharp/        @MarioGK
+/dart/          @shreyassanthu77
+/elixir/        @ryanwinchester
+/erlang/        @mikimaine
+/fortran/       @greuben92
+/fsharp/        @meenzen
+/java/          @xNaCly
+/ocaml/         @tjdevries
+/odin/          @jon-lipstate
+/php/           @wartab
+/python/        @BatikanHyt
+/roc/           @bhansconnect
+/rust/          @ThePrimeagen
+/typescript/    @ThePrimeagen
+/zig/           @ThePrimeagen


### PR DESCRIPTION
You might need to update repository settings if you want to do something like add some branch protection rules for codeowners.

For the initial version, I just added the people who contributed the language, except I put myself for Elixir, since that person already conceded it to moi.

Can be updated later with results from #84
You can also have more than one person, separated by space.