### PR TITLE
kotlin-multiplatform: update trailing comma rule in editorconfig

### DIFF
--- a/kotlin-multiplatform/.editorconfig
+++ b/kotlin-multiplatform/.editorconfig
@@ -2,4 +2,4 @@
 
 [*.{kt,kts}]
 max_line_length = 100
-ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_allow_trailing_comma_on_call_site = false

--- a/kotlin-multiplatform/test/LexerTest.kt
+++ b/kotlin-multiplatform/test/LexerTest.kt
@@ -17,8 +17,8 @@ class LexerTest {
             Token.RightSquirly,
             Token.Comma,
             Token.Semicolon,
-            Token.EndOfFile,
-        ),
+            Token.EndOfFile
+        )
     )
 
     @Test
@@ -71,8 +71,8 @@ class LexerTest {
             Token.Identifier("ten"),
             Token.RightParen,
             Token.Semicolon,
-            Token.EndOfFile,
-        ),
+            Token.EndOfFile
+        )
     )
 
     @Test
@@ -105,8 +105,8 @@ class LexerTest {
             Token.NotEquals,
             Token.Integer(9),
             Token.Semicolon,
-            Token.EndOfFile,
-        ),
+            Token.EndOfFile
+        )
     )
 
     @Test
@@ -137,8 +137,8 @@ class LexerTest {
             Token.False,
             Token.Semicolon,
             Token.RightSquirly,
-            Token.EndOfFile,
-        ),
+            Token.EndOfFile
+        )
     )
 
     @Test
@@ -153,8 +153,8 @@ class LexerTest {
             Token.StringLiteral("foobar"),
             Token.StringLiteral("foo bar"),
             Token.Illegal("\"foo bar baz"),
-            Token.EndOfFile,
-        ),
+            Token.EndOfFile
+        )
     )
 
     @Test
@@ -168,8 +168,8 @@ class LexerTest {
             Token.Integer(2),
             Token.RightBracket,
             Token.Semicolon,
-            Token.EndOfFile,
-        ),
+            Token.EndOfFile
+        )
     )
 
     @Test
@@ -184,8 +184,8 @@ class LexerTest {
             Token.Colon,
             Token.StringLiteral("bar"),
             Token.RightSquirly,
-            Token.EndOfFile,
-        ),
+            Token.EndOfFile
+        )
     )
 
     private fun testExpectedTokensInInput(input: String, expectedTokens: List<Token>) {


### PR DESCRIPTION
Linting currently fails in `kotlin-multiplatform`, due to a trailing comma rule in our `.editorconfig`. It wants to reformat this:
```
Div({
    classes(ReplStyleSheet.replLayout)
}) {
```
...to this:
```
Div({
    classes(ReplStyleSheet.replLayout)
},) {
```
...which is just horrendous. So this PR disables that rule, and reformats `LexerTest` to comply.