### PR TITLE
kotlin-multiplatform: switch ktlint gradle plugin to kotlinter

### DIFF
--- a/kotlin-multiplatform/.editorconfig
+++ b/kotlin-multiplatform/.editorconfig
@@ -2,4 +2,3 @@
 
 [*.{kt,kts}]
 max_line_length = 100
-ij_kotlin_allow_trailing_comma_on_call_site = true

--- a/kotlin-multiplatform/Dockerfile
+++ b/kotlin-multiplatform/Dockerfile
@@ -4,10 +4,10 @@ COPY --chown=gradle:gradle . /app
 WORKDIR /app
 
 CMD echo "===> Formatting"
-CMD ./gradlew ktlintFormat
+CMD ./gradlew formatKotlin
 
 CMD echo "===> Linting"
-CMD ./gradlew ktlintCheck
+CMD ./gradlew lintKotlin
 
 CMD echo "===> Testing"
 CMD ./gradlew cleanAllTests allTests

--- a/kotlin-multiplatform/Makefile
+++ b/kotlin-multiplatform/Makefile
@@ -17,11 +17,11 @@ clean:
 
 fmt:
 	@echo "===> Formatting"
-	./gradlew ktlintFormat
+	./gradlew formatKotlin
 
 lint:
 	@echo "===> Linting"
-	./gradlew ktlintCheck
+	./gradlew lintKotlin
 
 test: test-lexer test-ast test-parser
 	@echo "===> Testing EVERYTHING"

--- a/kotlin-multiplatform/build.gradle.kts
+++ b/kotlin-multiplatform/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("multiplatform") version "1.8.20"
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
+    id("org.jmailen.kotlinter") version "3.15.0"
 }
 
 group = "dev.hermannm"

--- a/kotlin-multiplatform/jvm/build.gradle.kts
+++ b/kotlin-multiplatform/jvm/build.gradle.kts
@@ -1,6 +1,6 @@
 ﻿plugins {
     kotlin("multiplatform") version "1.8.20"
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
+    id("org.jmailen.kotlinter")
     application
 }
 

--- a/kotlin-multiplatform/make.cmd
+++ b/kotlin-multiplatform/make.cmd
@@ -39,12 +39,12 @@ endlocal
 
 :"fmt"
 	echo ^=^=^=^> Formatting
-	call .\gradlew.bat ktlintFormat
+	call .\gradlew.bat formatKotlin
 	if %ready%=="yes" goto "lint" else goto exit
 
 :"lint"
 	echo ^=^=^=^> Linting
-	call .\gradlew.bat ktlintCheck
+	call .\gradlew.bat lintKotlin
 	if %ready%=="yes" goto "test" else goto exit
 
 :"test"

--- a/kotlin-multiplatform/web/build.gradle.kts
+++ b/kotlin-multiplatform/web/build.gradle.kts
@@ -1,6 +1,6 @@
 ﻿plugins {
     kotlin("multiplatform") version "1.8.20"
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
+    id("org.jmailen.kotlinter")
     id("org.jetbrains.compose").version("1.4.0")
 }
 


### PR DESCRIPTION
Linting currently fails in `kotlin-multiplatform`, due to a trailing comma rule in our `.editorconfig`. Our linter wants to reformat this:
```
Div({
    classes(ReplStyleSheet.replLayout)
}) {
```
...to this:
```
Div({
    classes(ReplStyleSheet.replLayout)
},) {
```
...which is just horrendous. This is because our current plugin `org.jlleitschuh.gradle.ktlint` uses an old version of `ktlint`, which does not work well with trailing commas. This PR switches the linter to `org.jmailen.kotlinter`, which uses a new, better version of `ktlint`.