### PR TITLE
kotlin-multiplatform: change package name

### DIFF
--- a/kotlin-multiplatform/Makefile
+++ b/kotlin-multiplatform/Makefile
@@ -28,7 +28,7 @@ test: test-lexer test-ast test-parser
 
 test-lexer:
 	@echo "===> Testing lexer"
-	./gradlew test --tests dev.hermannm.monkeylang.LexerTest
+	./gradlew test --tests LexerTest
 
 test-ast:
 	@echo "===> Testing AST"

--- a/kotlin-multiplatform/build.gradle.kts
+++ b/kotlin-multiplatform/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("org.jmailen.kotlinter") version "3.15.0"
 }
 
-group = "dev.hermannm"
 version = "0.1.0"
 
 repositories {

--- a/kotlin-multiplatform/jvm/build.gradle.kts
+++ b/kotlin-multiplatform/jvm/build.gradle.kts
@@ -4,7 +4,6 @@
     application
 }
 
-group = "dev.hermannm"
 version = "0.1.0"
 
 repositories {
@@ -41,7 +40,7 @@ kotlin {
 }
 
 application {
-    mainClass.set("dev.hermannm.monkeylang.jvm.ReplKt")
+    mainClass.set("jvm.ReplKt")
 }
 
 // From https://slack-chats.kotlinlang.org/t/522898/how-should-i-correctly-replace-application-mainclass-set-com

--- a/kotlin-multiplatform/jvm/src/Repl.kt
+++ b/kotlin-multiplatform/jvm/src/Repl.kt
@@ -1,6 +1,6 @@
-package dev.hermannm.monkeylang.jvm
+package jvm
 
-import dev.hermannm.monkeylang.Lexer
+import Lexer
 
 fun main() {
     while (true) {

--- a/kotlin-multiplatform/make.cmd
+++ b/kotlin-multiplatform/make.cmd
@@ -54,7 +54,7 @@ endlocal
 
 :"test-lexer"
 	echo ^=^=^=^> Testing lexer
-	call .\gradlew.bat test --tests dev.hermannm.monkeylang.LexerTest
+	call .\gradlew.bat test --tests LexerTest
 	if %test_all%=="yes" goto "test-ast" else goto exit
 
 :"test-ast"

--- a/kotlin-multiplatform/src/DocumentRange.kt
+++ b/kotlin-multiplatform/src/DocumentRange.kt
@@ -1,5 +1,3 @@
-package dev.hermannm.monkeylang
-
 data class DocumentPosition(val line: Int, val column: Int) : Comparable<DocumentPosition> {
     init {
         require(line >= 1) { "DocumentPosition line must be >= 1" }

--- a/kotlin-multiplatform/src/Lexer.kt
+++ b/kotlin-multiplatform/src/Lexer.kt
@@ -1,6 +1,4 @@
-﻿package dev.hermannm.monkeylang
-
-import kotlin.text.isWhitespace
+﻿import kotlin.text.isWhitespace
 
 class Lexer(private val input: String) : Iterator<Token> {
     private var currentIndex: Int = 0

--- a/kotlin-multiplatform/src/Token.kt
+++ b/kotlin-multiplatform/src/Token.kt
@@ -1,6 +1,4 @@
-﻿package dev.hermannm.monkeylang
-
-enum class TokenType {
+﻿enum class TokenType {
     Illegal,
     EndOfFile,
 

--- a/kotlin-multiplatform/test/LexerTest.kt
+++ b/kotlin-multiplatform/test/LexerTest.kt
@@ -1,6 +1,4 @@
-﻿package dev.hermannm.monkeylang
-
-import kotlin.test.Test
+﻿import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class LexerTest {

--- a/kotlin-multiplatform/test/TestToken.kt
+++ b/kotlin-multiplatform/test/TestToken.kt
@@ -1,3 +1,1 @@
-package dev.hermannm.monkeylang
-
 data class TestToken(val type: TokenType, val literal: String)

--- a/kotlin-multiplatform/web/build.gradle.kts
+++ b/kotlin-multiplatform/web/build.gradle.kts
@@ -4,7 +4,6 @@
     id("org.jetbrains.compose").version("1.4.0")
 }
 
-group = "dev.hermannm"
 version = "0.1.0"
 
 repositories {

--- a/kotlin-multiplatform/web/src/DebugConsole.kt
+++ b/kotlin-multiplatform/web/src/DebugConsole.kt
@@ -1,4 +1,4 @@
-﻿package dev.hermannm.monkeylang.web
+﻿package web
 
 import androidx.compose.runtime.* // ktlint-disable no-wildcard-imports
 import org.jetbrains.compose.web.dom.* // ktlint-disable no-wildcard-imports

--- a/kotlin-multiplatform/web/src/DebugStyleSheet.kt
+++ b/kotlin-multiplatform/web/src/DebugStyleSheet.kt
@@ -1,4 +1,4 @@
-package dev.hermannm.monkeylang.web
+package web
 
 import org.jetbrains.compose.web.css.* // ktlint-disable no-wildcard-imports
 

--- a/kotlin-multiplatform/web/src/DebugTextEditor.kt
+++ b/kotlin-multiplatform/web/src/DebugTextEditor.kt
@@ -1,4 +1,4 @@
-package dev.hermannm.monkeylang.web
+package web
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect

--- a/kotlin-multiplatform/web/src/DebugTokenView.kt
+++ b/kotlin-multiplatform/web/src/DebugTokenView.kt
@@ -1,9 +1,9 @@
-package dev.hermannm.monkeylang.web
+package web
 
+import Lexer
+import Token
+import TokenType
 import androidx.compose.runtime.Composable
-import dev.hermannm.monkeylang.Lexer
-import dev.hermannm.monkeylang.Token
-import dev.hermannm.monkeylang.TokenType
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text

--- a/kotlin-multiplatform/web/src/Main.kt
+++ b/kotlin-multiplatform/web/src/Main.kt
@@ -1,4 +1,4 @@
-package dev.hermannm.monkeylang.web
+package web
 
 import org.jetbrains.compose.web.css.Style
 import org.jetbrains.compose.web.renderComposable

--- a/kotlin-multiplatform/web/src/Monaco.kt
+++ b/kotlin-multiplatform/web/src/Monaco.kt
@@ -1,4 +1,4 @@
-package dev.hermannm.monkeylang.web
+package web
 
 import androidx.compose.runtime.NoLiveLiterals
 import org.w3c.dom.HTMLElement


### PR DESCRIPTION
Changing the package name of the `kotlin-multiplatform` implementation, since I'm working with @ekgame and @LizAinslie now, so it doesn't make sense to use my domain anymore.