### PR TITLE
cpp: Use string_view to avoid 2 unnecessary copies of input.

### DIFF
--- a/cpp/lexer/lexer.cc
+++ b/cpp/lexer/lexer.cc
@@ -4,7 +4,7 @@
 #include <exception>
 
 
-lexer::lexer(const std::string input)
+lexer::lexer(std::string_view input)
   : input_{input},
     position_{0},
     read_position_{1},

--- a/cpp/lexer/lexer.hh
+++ b/cpp/lexer/lexer.hh
@@ -2,6 +2,7 @@
 
 
 #include <string>
+#include <string_view>
 #include <variant>
 
 #include <cstdint>
@@ -33,13 +34,13 @@ struct token final {
 
 class lexer final {
   private:
-    std::string input_;  // The user's input
+    std::string_view input_;  // The user's input
     size_t position_;  // Point to the current byte
     size_t read_position_;  // Peeks at the next byte
     char byte_;  // The byte to evaluate
 
   public:
-    lexer(const std::string);
+    lexer(std::string_view input);
     void read_char(void) noexcept;
     void next_token(token &) noexcept;
 };


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/ThePrimeagen/ts-rust-zig-deez/pull/16#discussion_r1209688474).