### PR TITLE
Elixir lexer now with 300% more blazingly fast and 300% less memory usage

### DIFF
--- a/elixir/bench/tokenize_word_bench.exs
+++ b/elixir/bench/tokenize_word_bench.exs
@@ -1,0 +1,49 @@
+input = """
+  let result = add(five, ten);
+  =+(){},;
+  let five = 5;
+  let ten = 10;
+  let add = fn(x, y) {
+  x + y;
+  };
+  let result = add(five, ten);
+  !-/*5;
+  5 < 10 > 5;
+  if (5 < 10) {
+  return true;
+  } else {
+  return false;
+  }
+  10 == 10;
+  11 != 10;
+  return 5;
+  return 10;
+  return add(15);
+  let returnfoo = 1;
+  return returnfoo;
+  """
+
+expected_tokens = Monkey.OldLexer.init(input)
+actual_tokens = Monkey.Lexer.init(input)
+
+if actual_tokens != expected_tokens do
+  Enum.zip([actual_tokens, expected_tokens])
+  |> Enum.each(fn
+    {t, t} -> IO.inspect(t)
+    {actual, expected} -> 
+      IO.inspect([actual: actual, expected: expected])
+      raise "mismatched output"
+  end)
+end
+
+Benchee.run(
+  %{
+    # copy + paste old code into `Monkey.OldLexer to compare. Not checked in`
+    # "OldLexer" => fn -> Monkey.OldLexer.init(input) end,
+    "Lexer" => fn -> Monkey.Lexer.init(input) end
+  },
+  warmup: 20,
+  time: 20,
+  memory_time: 5,
+  reduction_time: 5
+)

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -21,6 +21,7 @@ defmodule Monkey.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:benchee, "~> 1.1", only: [:dev, :test], runtime: false}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/elixir/mix.lock
+++ b/elixir/mix.lock
@@ -1,0 +1,5 @@
+%{
+  "benchee": {:hex, :benchee, "1.1.0", "f3a43817209a92a1fade36ef36b86e1052627fd8934a8b937ac9ab3a76c43062", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}], "hexpm", "7da57d545003165a012b587077f6ba90b89210fd88074ce3c60ce239eb5e6d93"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
+  "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
+}


### PR DESCRIPTION
Was thinking about this, and worked in a bunch of optimisations to make things ✨ _**blazingly faster**_ ✨ 

**TL;DR - 3x faster, 3x less memory usage**

- rather than doing a tail recursive loop in `lex/2`, and calling `tokenize/2` to return a tuple of `{token, rest}`, just do everything pure tail recursively. This is the main speed and memory boost because:
  - building a tuple to return multiple values takes a bit of time
  - extracting values when the function returns takes a bit of time
  - it has to be done on heap, which is slower
  - it needs memory to be allocated on the heap, which takes time
  - it needs heap memory to eventually be GCed
  - calling a function to get a value, and then doing something with that value means the BEAM has to manage stack allocation, continuation pointers, stack deallocation etc. If everything is completely tail-call optimised, the BEAM can just set VM registers to pass arguments, and not worry about managing the stack, or return values etc, and use `call_last` instruction rather than `call` - just is faster.
- when matching identifiers/numbers, instead of accumulating a character at a time into an iolist, just keep track of the integer position into the string containing the token. Then when we hit the end of the token, do a single binary pattern match with the calculated length. This gives us a sub binary match - which is just a reference into the original string in memory, and doesn't involve any copying, or need to create GC building and intermediate accumulator.
- when matching a keyword, we've already got a huge headstart, so keep that match length, and just check the next character. If it's not another letter, we can just directly return a tuple. If it is, then carry on as if it were an identifier
- rather than splitting logic for detecting whitespace/eof etc into a separate function, do as much as possible in one match. Means only one pattern match operation, but more importantly, it allows the compiler to see all the potential cases, and generate more optimal code based on them (in this case it builds a _sort-of_ trie lookup based on prefix characters combinations from the hard coded symbols/keywords/whitespace, with a fallback for identifiers/numbers, but depending on cases could do linear search/binary search).
- refactored main matches to be in a `case` expression rather than separate function heads. They both work identically (and have verified the generated BEAM byte code is the same in both cases), but because we're passing `tokens`, and doing another function call in each case, it gets messier as function heads. Because `tokens` is already an argument, we can just pass that along rather than having to explicitly declare it as an argument each time.
- added a benchmark too, which I was using. Have commented out benchmarking the old code (cause it's not checked in), but to compare, you can copy+paste the old code into `Monkey.OldLexer`

Apologies to @ryanwinchester . Was gonna make just a couple of tweaks, but ended up touching pretty much all the original code. The same logic is still there. It's just all being called a bit differently.

```
Operating System: macOS
CPU Information: Apple M1 Pro
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.14.5
Erlang 26.0.1

Benchmark suite executing with the following configuration:
warmup: 20 s
time: 20 s
memory time: 5 s
reduction time: 5 s
parallel: 1
inputs: none specified
Estimated total run time: 1.67 min

Benchmarking Lexer ...
Benchmarking OldLexer ...

Name               ips        average  deviation         median         99th %
Lexer         515.43 K        1.94 μs  ±1439.50%        1.83 μs        2.13 μs
OldLexer      180.10 K        5.55 μs   ±316.21%        5.29 μs        9.79 μs

Comparison:
Lexer         515.43 K
OldLexer      180.10 K - 2.86x slower +3.61 μs

Memory usage statistics:

Name        Memory usage
Lexer            7.95 KB
OldLexer        24.13 KB - 3.04x memory usage +16.19 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name     Reduction count
Lexer                394
OldLexer             950 - 2.41x reduction count +556

**All measurements for reduction count were the same**
```