### PR TITLE
Feat: Complete C++ Tokenizer

### DIFF
--- a/cpp/lexer/lexer.hh
+++ b/cpp/lexer/lexer.hh
@@ -4,43 +4,101 @@
 #include <string>
 #include <string_view>
 #include <variant>
-
+#include <unordered_map>
 #include <cstdint>
 
 
 enum class token_type {
-    illegal,
-    eof,
-    identifier,
-    integer,
-    assign,
-    plus,
-    comma,
-    semicolon,
-    lparen,
-    rparen,
-    lsquirly,
-    rsquirly,
-    function,
-    let
+    Identifier,
+    Integer,
+
+    Illegal,
+    Eof,
+    Assign,
+
+    Bang,
+    Dash,
+    ForwardSlash,
+    Asterisk,
+    Equal,
+    NotEqual,
+    LessThan,
+    GreaterThan,
+
+    Plus,
+    Comma,
+    Semicolon,
+    LParen,
+    RParen,
+    LSquirly,
+    RSquirly,
+
+    Function,
+    Let,
+
+    If,
+    Else,
+    Return,
+    True,
+    False
 };
 
 
 struct token final {
     token_type type;
-    std::variant<std::string, char> literal;
+    std::string_view literal;
+
+    inline token() : type(token_type::Illegal)
+    {}
+    inline token (const token&) = default;
+    inline token(token &&) = default; 
+    inline token(token_type t, std::string_view literal_)
+        : type(t)
+        , literal(literal_)
+    {}
+    token &operator=(const token &) = default;
+    token &operator=(token &&) = default;
+
+
+    inline void set(token_type t, std::string_view literal_)
+    {
+        type = t;
+        literal = literal_;
+    }
+
+    inline void set(token_type t, std::string::iterator iter)
+    {
+        type = t;
+        literal = std::string_view(iter,iter+1);
+    }
 };
 
 
 class lexer final {
-  private:
-    std::string_view input_;  // The user's input
-    size_t position_;  // Point to the current byte
-    size_t read_position_;  // Peeks at the next byte
-    char byte_;  // The byte to evaluate
+private:
 
-  public:
-    lexer(std::string_view input);
-    void read_char(void) noexcept;
+    // Enable heterogenous lookup in unordered_map, see https://en.cppreference.com/w/cpp/container/unordered_map/find
+    struct string_hash
+    {
+        using hash_type = std::hash<std::string_view>;
+        using is_transparent = void;
+
+        std::size_t operator()(const char *str) const { return hash_type{}(str); }
+        std::size_t operator()(std::string_view str) const { return hash_type{}(str); }
+        std::size_t operator()(std::string const &str) const { return hash_type{}(str); }
+    };
+
+    static const std::unordered_map<std::string, token_type, string_hash, std::equal_to<>> keywords;
+
+    std::string input;  // The user's input
+    std::string::iterator ch;  // The byte to evaluate
+
+    void read_char() noexcept;
+    char peek() noexcept;
+    void skip_whitespace() noexcept;
+    std::string_view read_ident() noexcept;
+    std::string_view read_int() noexcept;
+public:
+    lexer(std::string &&input_);
     void next_token(token &) noexcept;
 };

--- a/cpp/tests.cc
+++ b/cpp/tests.cc
@@ -3,29 +3,22 @@
 
 #include "lexer/lexer.hh"
 
+#include <cstdint>
 
-void
-test_simple_input(void)
+#if __cplusplus < 202302L
+namespace std {
+    std::uint32_t to_underlying(auto e) {
+        return static_cast<unsigned>(e);
+    }
+}
+#endif
+
+void runTest(const std::string &name, lexer &lexer, std::vector<token> expected_tokens)
 {
-    std::string input{"=+(){},;"};
-
-    token expected_tokens[9] = {
-        {token_type::assign, '='},
-        {token_type::plus, '+'},
-        {token_type::lparen, '('},
-        {token_type::rparen, ')'},
-        {token_type::lsquirly, '{'},
-        {token_type::rsquirly, '}'},
-        {token_type::comma, ','},
-        {token_type::semicolon, ';'},
-        {token_type::eof, '\0'},
-    };
-
-    lexer lex{input};
     token token;
 
     for (auto &expected : expected_tokens) {
-        lex.next_token(token);
+        lexer.next_token(token);
 
         if (token.type != expected.type) {
             std::cerr
@@ -40,25 +33,168 @@ test_simple_input(void)
         else if (token.literal != expected.literal) {
             std::cerr
                 << "Expected token literal: "
-                << std::get<char>(expected.literal)
+                << expected.literal
                 << " got "
-                << std::get<char>(token.literal)
+                << token.literal
                 << '\n';
 
             std::exit(1);
         }
     }
 
-    std::cout << "All tests passed successfully\n";
+    std::cout << "Test '" << name << "' passed successfully\n";
+}
+
+void
+test_empty_input(void)
+{
+    std::string input{ "" };
+
+    std::vector<token> expected_tokens{
+        {token_type::Eof, "\0"}
+    };
+
+    lexer lex{ std::move(input) };
+
+    runTest("Empty Tests", lex, expected_tokens);
+    return;
+}
+
+void
+test_simple_input(void)
+{
+    std::string input{ "=+(){},;" };
+
+    std::vector<token> expected_tokens{
+        {token_type::Assign, "="},
+        {token_type::Plus, "+"},
+        {token_type::LParen, "("},
+        {token_type::RParen, ")"},
+        {token_type::LSquirly, "{"},
+        {token_type::RSquirly, "}"},
+        {token_type::Comma, ","},
+        {token_type::Semicolon, ";"},
+        {token_type::Eof, "\0"}
+    };
+
+    lexer lex{ std::move(input) };
+
+    runTest("Simple Tests", lex, expected_tokens);
+    return;
+}
+
+void
+test_complex_input(void)
+{
+    std::string input{ "let five = 5;\n"
+        "    let ten = 10;\n"
+        "    let add = fn(x, y) {\n"
+        "        x + y;\n"
+        "    };\n"
+        "    let result = add(five, ten);\n"
+        "!-/*5;\n"
+        "5 < 10 > 5;\n"
+        "if (5 < 10) {\n"
+        "    return true;\n"
+        "} else {\n"
+        "    return false;\n"
+        "}\n"
+        "10 == 10;\n"
+        "10 != 9;\n"
+    };
+
+    std::vector<token> expected_tokens{
+        {token_type::Let, "let"},
+        {token_type::Identifier, "five"},
+        {token_type::Assign, "="},
+        {token_type::Integer, "5"},
+        {token_type::Semicolon, ";"},
+        {token_type::Let, "let"},
+        {token_type::Identifier, "ten"},
+        {token_type::Assign, "="},
+        {token_type::Integer, "10"},
+        {token_type::Semicolon, ";"},
+        {token_type::Let, "let"},
+        {token_type::Identifier, "add"},
+        {token_type::Assign, "="},
+        {token_type::Function, "fn"},
+        {token_type::LParen, "("},
+        {token_type::Identifier, "x"},
+        {token_type::Comma, ","},
+        {token_type::Identifier, "y"},
+        {token_type::RParen, ")"},
+        {token_type::LSquirly, "{"},
+        {token_type::Identifier, "x"},
+        {token_type::Plus, "+"},
+        {token_type::Identifier, "y"},
+        {token_type::Semicolon, ";"},
+        {token_type::RSquirly, "}"},
+        {token_type::Semicolon, ";"},
+        {token_type::Let, "let"},
+        {token_type::Identifier, "result"},
+        {token_type::Assign, "="},
+        {token_type::Identifier, "add"},
+        {token_type::LParen, "("},
+        {token_type::Identifier, "five"},
+        {token_type::Comma, ","},
+        {token_type::Identifier, "ten"},
+        {token_type::RParen, ")"},
+        {token_type::Semicolon, ";"},
+        {token_type::Bang, "!"},
+        {token_type::Dash, "-"},
+        {token_type::ForwardSlash, "/"},
+        {token_type::Asterisk, "*"},
+        {token_type::Integer, "5"},
+        {token_type::Semicolon, ";"},
+        {token_type::Integer, "5"},
+        {token_type::LessThan, "<"},
+        {token_type::Integer, "10"},
+        {token_type::GreaterThan, ">"},
+        {token_type::Integer, "5"},
+        {token_type::Semicolon, ";"},
+        {token_type::If, "if"},
+        {token_type::LParen, "("},
+        {token_type::Integer, "5"},
+        {token_type::LessThan, "<"},
+        {token_type::Integer, "10"},
+        {token_type::RParen, ")"},
+        {token_type::LSquirly, "{"},
+        {token_type::Return, "return"},
+        {token_type::True, "true"},
+        {token_type::Semicolon, ";"},
+        {token_type::RSquirly, "}"},
+        {token_type::Else, "else"},
+        {token_type::LSquirly, "{"},
+        {token_type::Return, "return"},
+        {token_type::False, "false"},
+        {token_type::Semicolon, ";"},
+        {token_type::RSquirly, "}"},
+
+        {token_type::Integer, "10"},
+        {token_type::Equal, "=="},
+        {token_type::Integer, "10"},
+        {token_type::Semicolon, ";"},
+
+        {token_type::Integer, "10"},
+        {token_type::NotEqual, "!="},
+        {token_type::Integer, "9"},
+        {token_type::Semicolon, ";"},
+
+        {token_type::Eof, "\0"}
+    };
+
+    lexer lex{ std::move(input) };
+    runTest("Complex Tests", lex, expected_tokens);
 
     return;
 }
 
-
 int
 main(void)
 {
+    test_empty_input();
     test_simple_input();
+    test_complex_input();
 
     return 0;
 }


### PR DESCRIPTION
Most inmportantly this completes the Tokenizer in the cpp directory, up to the level in the "Rust lexer: Finished it" video.

Also includes several other changes:
- Keyword token types clased with C++ keywords, so capitalized all token types for uniformity
- Avoiding copy into Lexer is a good idea, but having it rely on a string_view with the contents possibly being deallocated elsewhere is potentially hazardous. Instead, move the string into the lexer.
- Conversely, tokens where overengineered using variants for literals: Made using them more dfficult, and special case for char needed only where the information is not even neeed. Replaced literals with string_view (but remember, now the literal does not live beyond the lexer's lifetime)
- Added contructor to token for easier codeing. Needed more red tape...
- replaced position based indexing into string with an iterator. Much more C++ style.
- Lexer no longer throws exception on empty input, just returns an EOF token. 
- Reduced C++ standard needed to c++20 as the only c++23 feature used was not worth it (see block inside "#if __cplusplus < 202302L" in test.cc